### PR TITLE
Migrate to Xdebug 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Changed
+- Migrated Xdebug configurations for PHP7.4 for Xdebug 3.
+
 ## [1.1.4] - 2019-06-11
 ### Added
 - autostart off for php7.3

--- a/README.md
+++ b/README.md
@@ -1,15 +1,27 @@
 # Docker Wordpress Image for Development
 This is development version of our [wordpress docker image](https://github.com/devgeniem/ubuntu-docker-wordpress) with xdebug enabled and opcache disabled.
 
-## Options
-If you want to use xdebug trace in your local editor you can set your ip address in `XDEBUG_REMOTE_HOST`.
+## Xdebug
+For debugging and profiling purposes this container comes with **Xdebug 3**. To enable Xdebug features, change its mode in `XDEBUG_MODE`.
 ```
-XDEBUG_REMOTE_HOST # Default: '10.254.254.254'
+XDEBUG_MODE=off # Off by default to optimize performance.
+```
+For different mode values see: https://xdebug.org/docs/all_settings#mode
+
+If you want to use Xdebug step debugger in your host machine's editor, you can set your Docker host's ip address in `XDEBUG_CLIENT_HOST`.
+```
+XDEBUG_CLIENT_HOST=10.254.254.254
 ```
 
-This container helps you to profile your site with xdebug but this comes with cost of slower development environment.
+You can also define the IDE session key in `${XDEBUG_IDE_KEY}`. By default it is a generic value: `DEBUG`.
 ```
-XDEBUG_ENABLE_PROFILE # Default: 0
+XDEBUG_IDE_KEY=DEBUG
 ```
 
-Set `XDEBUG_ENABLE_PROFILE=1` to enable profiling.
+If profiling features are enabled, tracing, profiling, and garbage collection statistics will be written to a location defined in `XDEBUG_OUTPUT_DIR`.
+
+```
+XDEBUG_OUTPUT_DIR=/tmp/xdebug # Default value.
+```
+
+For all environment variables for Xdebug, see the [Dockerfile](./Dockerfile)

--- a/ubuntu-php-7.4/Dockerfile
+++ b/ubuntu-php-7.4/Dockerfile
@@ -4,16 +4,25 @@ MAINTAINER Ville Pietarinen - Geniem Oy <ville.pietarinen-nospam@geniem.com>
 ENV \
     # Display errors for easier debugging
     PHP_DISPLAY_ERRORS="on" \
-    # Directory to store xdebug profiling
-    XDEBUG_DIR="/tmp/xdebug" \
+    # You can change this env to allow profiling or debugging your application with Xdebug.
+    # This is disabled by default because it adds plenty of overhead when it's not needed.
+    # Default: off
+    XDEBUG_MODE=off \
+    XDEBUG_IDE_KEY=DEBUG \
+    # Directory to store Xdebug profiling data
+    XDEBUG_OUTPUT_DIR="/tmp/xdebug" \
     # Use OSX IP address loopback hack: https://gist.githubusercontent.com/ralphschindler/535dc5916ccbd06f53c1b0ee5a868c93/raw/com.ralphschindler.docker_10254_alias.plist
     # This can be overridden by you
-    XDEBUG_REMOTE_HOST="10.254.254.254" \
-    XDEBUG_REMOTE_PORT="9000" \
-    # You can enable this env to allow profiling your application with xdebug trigger
-    # This is disabled by default because it adds plenty of overhead when it's not needed
-    # Default: disabled
-    XDEBUG_ENABLE_PROFILE=0
+    XDEBUG_CLIENT_HOST="10.254.254.254" \
+    # This is the default recommended port.
+    XDEBUG_CLIENT_PORT="9003" \
+    # Log to container's STDOUT.
+    XDEBUG_LOG=STDOUT \
+    # https://xdebug.org/docs/all_settings#start_with_request
+    XDEBUG_START_WITH_REQUEST=yes \
+    # https://xdebug.org/docs/all_settings#discover_client_host
+    XDEBUG_DISCOVER_CLIENT_HOST=false \
+
 
 # Install xdebug
 RUN \

--- a/ubuntu-php-7.4/etc/php/7.4/fpm/conf.d/xdebug.ini
+++ b/ubuntu-php-7.4/etc/php/7.4/fpm/conf.d/xdebug.ini
@@ -1,35 +1,10 @@
 [xdebug]
 
-; Enable php profiling with get param XDEBUG_PROFILE=1
-xdebug.profiler_output_dir=${XDEBUG_DIR}
-xdebug.profiler_output_name=cachegrind.out.%t.%p
-xdebug.profiler_enable_trigger=${XDEBUG_ENABLE_PROFILE}
-
-; Enable PHP tracing with get param XDEBUG_TRACE=1
-xdebug.trace_enable_trigger=1
-xdebug.trace_format=1
-xdebug.show_mem_delta=1
-xdebug.collect_return=1
-xdebug.trace_options=1
-xdebug.trace_output_dir=${XDEBUG_DIR}
-xdebug.trace_output_name=trace.%c
-
-; Enable dumping detailed info in the frontend when php fatals
-xdebug.collect_vars=on
-xdebug.collect_params=4
-xdebug.dump_globals=on
-xdebug.show_local_vars=on
-xdebug.dump.SERVER=HTTP_HOST
-xdebug.dump.COOKIE=*
-xdebug.dump.POST=*
-xdebug.dump.FILES=*
-xdebug.dump.SESSION=*
-
-; Enable remote debugging
-xdebug.remote_enable=1
-xdebug.remote_autostart=0
-xdebug.remote_connect_back=0
-xdebug.remote_handler=dbgp
-; This can be overridden in docker configs, use it for xdebug trace
-xdebug.remote_port=${XDEBUG_REMOTE_PORT}
-xdebug.remote_host=${XDEBUG_REMOTE_HOST}
+xdebug.mode=${XDEBUG_MODE}
+xdebug.client_host=${XDEBUG_CLIENT_HOST}
+xdebug.client_port=${XDEBUG_CLIENT_PORT}
+xdebug.start_with_request=${XDEBUG_START_WITH_REQUEST}
+xdebug.log=${XDEBUG_LOG}
+xdebug.idekey=${XDEBUG_IDE_KEY}
+xdebug.output_dir=${XDEBUG_OUTPUT_DIR}
+xdebug.discover_client_host=${XDEBUG_DISCOVER_CLIENT_HOST}


### PR DESCRIPTION
Migrate Xdebug configurations to work with version 3. Changes made based on the official upgrade guide:
https://xdebug.org/docs/upgrade_guide